### PR TITLE
Does Doorkeeper support 'token' in header?

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
 <span class="gp">$ </span>curl -G https://api.smartcitizen.me/v0/me?access_token<span class="o">=</span>OAUTH-TOKEN
 
 <span class="c"># OAuth2 Token (sent in a header)</span>
-<span class="gp">$ </span>curl -H <span class="s2">"Authorization: token OAUTH-TOKEN"</span> https://api.smartcitizen.me/v0/me
+<span class="gp">$ </span>curl -H <span class="s2">"Authorization: Bearer OAUTH-TOKEN"</span> https://api.smartcitizen.me/v0/me
 </code></pre>
 
 <aside class="success">This is the recommended and safest way to access the API.</aside>


### PR DESCRIPTION
I just tried following the OAuth2 docs: http://developer.smartcitizen.me/#authentication

But was **unable** to get authenticated with **token**
`curl -H "Authorization: token OAUTH-TOKEN"`

But it **worked** when I changed it to **Bearer:**
`curl -H "Authorization: Bearer OAUTH-TOKEN"`

Here is a discussion on the gems gh:
https://github.com/doorkeeper-gem/doorkeeper/issues/46